### PR TITLE
Add new method MoveWindowHandle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # VirtualDesktop
-V1.4.1, 2019-07-15
+V1.4.2, 2019-12-13
 
 C# command line tool to manage virtual desktops in Windows 10<br><br>
 (look for a powershell version here: https://gallery.technet.microsoft.com/Powershell-commands-to-d0e79cc5)
@@ -42,6 +42,8 @@ Virtual desktop numbers start with 0.
 **/MoveWindow:(s)**  move process with name (s) to desktop with number in pipeline (short: /mw).
 
 **/MoveWindow:(n)**  move process with id (n) to desktop with number in pipeline (short: /mw).
+
+**/MoveWindowHandle:(n)**  move window with handle (n) to desktop with number in pipeline (short: /mwh).
 
 **/MoveActiveWindow**  move active window to desktop with number in pipeline (short: /maw).
 

--- a/VirtualDesktop.cs
+++ b/VirtualDesktop.cs
@@ -1,5 +1,5 @@
 // Author: Markus Scholtes, 2019
-// Version 1.4.1, 2019-07-15
+// Version 1.4.2, 2019-12-13
 // Version for Windows 10 1809
 // Compile with:
 // C:\Windows\Microsoft.NET\Framework\v4.0.30319\csc.exe VirtualDesktop.cs
@@ -883,6 +883,29 @@ namespace VDeskTool
 									}
 								}
 								break;
+								
+							case "MOVEWINDOWHANDLE": // move window to desktop in rc
+							case "MWH":
+								if (int.TryParse(groups[2].Value, out iParam))
+								{ // check if parameter is an integer
+									if (iParam > 0)
+									{ // check if parameter is greater than 0
+										try
+										{ 
+											// use window handle and move window
+											VirtualDesktop.Desktop.FromIndex(rc).MoveWindow((IntPtr)iParam);
+											if (verbose) Console.WriteLine("Window to handle id " + groups[2].Value + " moved to desktop " + rc.ToString());
+										}
+										catch
+										{ // error while seeking
+											if (verbose) Console.WriteLine("Window to handle id " + groups[2].Value + " not found or move failed");
+											rc = -1;
+										}
+									}
+									else
+										rc = -1;
+								}
+								break;
 
 							case "ISWINDOWPINNED": // is window pinned to all desktops
 							case "IWP":
@@ -1202,7 +1225,7 @@ namespace VDeskTool
 
     static void HelpScreen()
     {
-    	Console.WriteLine("VirtualDesktop.exe\t\t\t\tMarkus Scholtes, 2019, v1.4.1\n");
+    	Console.WriteLine("VirtualDesktop.exe\t\t\t\tMarkus Scholtes, 2019, v1.4.2\n");
 
     	Console.WriteLine("Command line tool to manage the virtual desktops of Windows 10.");
     	Console.WriteLine("Parameters can be given as a sequence of commands. The result - most of the");

--- a/VirtualDesktop1607.cs
+++ b/VirtualDesktop1607.cs
@@ -1,5 +1,5 @@
 // Author: Markus Scholtes, 2019
-// Version 1.4.1, 2019-07-15
+// Version 1.4.2, 2019-12-13
 // Version for Windows 10 1607 to 1709 or Windows Server 2016
 // Compile with:
 // C:\Windows\Microsoft.NET\Framework\v4.0.30319\csc.exe VirtualDesktop1607.cs
@@ -874,6 +874,29 @@ namespace VDeskTool
 									}
 								}
 								break;
+								
+							case "MOVEWINDOWHANDLE": // move window to desktop in rc
+							case "MWH":
+								if (int.TryParse(groups[2].Value, out iParam))
+								{ // check if parameter is an integer
+									if (iParam > 0)
+									{ // check if parameter is greater than 0
+										try
+										{ 
+											// use window handle and move window
+											VirtualDesktop.Desktop.FromIndex(rc).MoveWindow((IntPtr)iParam);
+											if (verbose) Console.WriteLine("Window to handle id " + groups[2].Value + " moved to desktop " + rc.ToString());
+										}
+										catch
+										{ // error while seeking
+											if (verbose) Console.WriteLine("Window to handle id " + groups[2].Value + " not found or move failed");
+											rc = -1;
+										}
+									}
+									else
+										rc = -1;
+								}
+								break;
 
 							case "ISWINDOWPINNED": // is window pinned to all desktops
 							case "IWP":
@@ -1193,7 +1216,7 @@ namespace VDeskTool
 
     static void HelpScreen()
     {
-    	Console.WriteLine("VirtualDesktop.exe\t\t\t\tMarkus Scholtes, 2019, v1.4.1\n");
+    	Console.WriteLine("VirtualDesktop.exe\t\t\t\tMarkus Scholtes, 2019, v1.4.2\n");
 
     	Console.WriteLine("Command line tool to manage the virtual desktops of Windows 10.");
     	Console.WriteLine("Parameters can be given as a sequence of commands. The result - most of the");

--- a/VirtualDesktop1803.cs
+++ b/VirtualDesktop1803.cs
@@ -1,5 +1,5 @@
 // Author: Markus Scholtes, 2019
-// Version 1.4.1, 2019-07-15
+// Version 1.4.2, 2019-12-13
 // Version for Windows 10 1803
 // Compile with:
 // C:\Windows\Microsoft.NET\Framework\v4.0.30319\csc.exe VirtualDesktop1803.cs
@@ -877,6 +877,29 @@ namespace VDeskTool
 								}
 								break;
 
+							case "MOVEWINDOWHANDLE": // move window to desktop in rc
+							case "MWH":
+								if (int.TryParse(groups[2].Value, out iParam))
+								{ // check if parameter is an integer
+									if (iParam > 0)
+									{ // check if parameter is greater than 0
+										try
+										{ 
+											// use window handle and move window
+											VirtualDesktop.Desktop.FromIndex(rc).MoveWindow((IntPtr)iParam);
+											if (verbose) Console.WriteLine("Window to handle id " + groups[2].Value + " moved to desktop " + rc.ToString());
+										}
+										catch
+										{ // error while seeking
+											if (verbose) Console.WriteLine("Window to handle id " + groups[2].Value + " not found or move failed");
+											rc = -1;
+										}
+									}
+									else
+										rc = -1;
+								}
+								break;
+
 							case "ISWINDOWPINNED": // is window pinned to all desktops
 							case "IWP":
 								if (int.TryParse(groups[2].Value, out iParam))
@@ -1195,7 +1218,7 @@ namespace VDeskTool
 
     static void HelpScreen()
     {
-    	Console.WriteLine("VirtualDesktop.exe\t\t\t\tMarkus Scholtes, 2019, v1.4.1\n");
+    	Console.WriteLine("VirtualDesktop.exe\t\t\t\tMarkus Scholtes, 2019, v1.4.2\n");
 
     	Console.WriteLine("Command line tool to manage the virtual desktops of Windows 10.");
     	Console.WriteLine("Parameters can be given as a sequence of commands. The result - most of the");


### PR DESCRIPTION
Add new method MoveWindowHandle which can MoveWindow by Handle. 
**/MoveWindowHandle:(n)**В  move window with handle (n) to desktop with number in pipeline (short: /mwh).

Why need another method then use existing /MoveWindow? Because /MoveWindow use process id whitch is int as handle.



