### PR TITLE
Optimized FindWindow()

### DIFF
--- a/VirtualDesktop.cs
+++ b/VirtualDesktop.cs
@@ -729,9 +729,20 @@ Console.WriteLine("Name of desktop: " + desktopName);
 		// find first window with string in title
 		public static WindowInformation FindWindow(string WindowTitle)
 		{
-			WindowInformationList = new List<WindowInformation>();
-			EnumWindows(callBackPtr, IntPtr.Zero);
-			WindowInformation result = WindowInformationList.Find(x => x.Title.IndexOf(WindowTitle, StringComparison.OrdinalIgnoreCase) >= 0);
+			StringBuilder sb = new StringBuilder();
+			WindowInformation result = null;
+			EnumWindows((hWnd, lParam) =>
+			{
+				if (GetWindowText((IntPtr)hWnd, sb, sb.Capacity) > 0)
+				{
+					if (sb.ToString() == WindowTitle)
+					{
+						result = new WindowInformation {Handle = hWnd, Title = sb.ToString()};
+						return false;
+					}
+				}
+				return true;
+			}, IntPtr.Zero);
 			return result;
 		}
 	}

--- a/VirtualDesktop.cs
+++ b/VirtualDesktop.cs
@@ -733,6 +733,8 @@ Console.WriteLine("Name of desktop: " + desktopName);
 			WindowInformation result = null;
 			EnumWindows((hWnd, lParam) =>
 			{
+				int length = GetWindowTextLength((IntPtr)hWnd);
+				sb.EnsureCapacity(length);
 				if (GetWindowText((IntPtr)hWnd, sb, sb.Capacity) > 0)
 				{
 					if (sb.ToString() == WindowTitle)

--- a/VirtualDesktop11-24H2.cs
+++ b/VirtualDesktop11-24H2.cs
@@ -724,9 +724,20 @@ namespace VirtualDesktop
 		// find first window with string in title
 		public static WindowInformation FindWindow(string WindowTitle)
 		{
-			WindowInformationList = new List<WindowInformation>();
-			EnumWindows(callBackPtr, IntPtr.Zero);
-			WindowInformation result = WindowInformationList.Find(x => x.Title.IndexOf(WindowTitle, StringComparison.OrdinalIgnoreCase) >= 0);
+			StringBuilder sb = new StringBuilder();
+			WindowInformation result = null;
+			EnumWindows((hWnd, lParam) =>
+			{
+				if (GetWindowText((IntPtr)hWnd, sb, sb.Capacity) > 0)
+				{
+					if (sb.ToString() == WindowTitle)
+					{
+						result = new WindowInformation {Handle = hWnd, Title = sb.ToString()};
+						return false;
+					}
+				}
+				return true;
+			}, IntPtr.Zero);
 			return result;
 		}
 	}

--- a/VirtualDesktop11-24H2.cs
+++ b/VirtualDesktop11-24H2.cs
@@ -728,6 +728,8 @@ namespace VirtualDesktop
 			WindowInformation result = null;
 			EnumWindows((hWnd, lParam) =>
 			{
+				int length = GetWindowTextLength((IntPtr)hWnd);
+				sb.EnsureCapacity(length);
 				if (GetWindowText((IntPtr)hWnd, sb, sb.Capacity) > 0)
 				{
 					if (sb.ToString() == WindowTitle)

--- a/VirtualDesktop11.cs
+++ b/VirtualDesktop11.cs
@@ -723,9 +723,20 @@ namespace VirtualDesktop
 		// find first window with string in title
 		public static WindowInformation FindWindow(string WindowTitle)
 		{
-			WindowInformationList = new List<WindowInformation>();
-			EnumWindows(callBackPtr, IntPtr.Zero);
-			WindowInformation result = WindowInformationList.Find(x => x.Title.IndexOf(WindowTitle, StringComparison.OrdinalIgnoreCase) >= 0);
+			StringBuilder sb = new StringBuilder();
+			WindowInformation result = null;
+			EnumWindows((hWnd, lParam) =>
+			{
+				if (GetWindowText((IntPtr)hWnd, sb, sb.Capacity) > 0)
+				{
+					if (sb.ToString() == WindowTitle)
+					{
+						result = new WindowInformation {Handle = hWnd, Title = sb.ToString()};
+						return false;
+					}
+				}
+				return true;
+			}, IntPtr.Zero);
 			return result;
 		}
 	}

--- a/VirtualDesktop11.cs
+++ b/VirtualDesktop11.cs
@@ -727,6 +727,8 @@ namespace VirtualDesktop
 			WindowInformation result = null;
 			EnumWindows((hWnd, lParam) =>
 			{
+				int length = GetWindowTextLength((IntPtr)hWnd);
+				sb.EnsureCapacity(length);
 				if (GetWindowText((IntPtr)hWnd, sb, sb.Capacity) > 0)
 				{
 					if (sb.ToString() == WindowTitle)

--- a/VirtualDesktopServer2016.cs
+++ b/VirtualDesktopServer2016.cs
@@ -652,6 +652,8 @@ namespace VirtualDesktop
 			WindowInformation result = null;
 			EnumWindows((hWnd, lParam) =>
 			{
+				int length = GetWindowTextLength((IntPtr)hWnd);
+				sb.EnsureCapacity(length);
 				if (GetWindowText((IntPtr)hWnd, sb, sb.Capacity) > 0)
 				{
 					if (sb.ToString() == WindowTitle)

--- a/VirtualDesktopServer2016.cs
+++ b/VirtualDesktopServer2016.cs
@@ -648,9 +648,20 @@ namespace VirtualDesktop
 		// find first window with string in title
 		public static WindowInformation FindWindow(string WindowTitle)
 		{
-			WindowInformationList = new List<WindowInformation>();
-			EnumWindows(callBackPtr, IntPtr.Zero);
-			WindowInformation result = WindowInformationList.Find(x => x.Title.IndexOf(WindowTitle, StringComparison.OrdinalIgnoreCase) >= 0);
+			StringBuilder sb = new StringBuilder();
+			WindowInformation result = null;
+			EnumWindows((hWnd, lParam) =>
+			{
+				if (GetWindowText((IntPtr)hWnd, sb, sb.Capacity) > 0)
+				{
+					if (sb.ToString() == WindowTitle)
+					{
+						result = new WindowInformation {Handle = hWnd, Title = sb.ToString()};
+						return false;
+					}
+				}
+				return true;
+			}, IntPtr.Zero);
 			return result;
 		}
 	}

--- a/VirtualDesktopServer2022.cs
+++ b/VirtualDesktopServer2022.cs
@@ -706,9 +706,20 @@ Console.WriteLine("Name of desktop: " + desktopName);
 		// find first window with string in title
 		public static WindowInformation FindWindow(string WindowTitle)
 		{
-			WindowInformationList = new List<WindowInformation>();
-			EnumWindows(callBackPtr, IntPtr.Zero);
-			WindowInformation result = WindowInformationList.Find(x => x.Title.IndexOf(WindowTitle, StringComparison.OrdinalIgnoreCase) >= 0);
+			StringBuilder sb = new StringBuilder();
+			WindowInformation result = null;
+			EnumWindows((hWnd, lParam) => 
+			{
+				if (GetWindowText((IntPtr)hWnd, sb, sb.Capacity) > 0)
+				{
+					if (sb.ToString() == WindowTitle)
+					{
+						result = new WindowInformation {Handle = hWnd, Title = sb.ToString()};
+						return false;
+					}
+				}
+				return true;
+			}, IntPtr.Zero);
 			return result;
 		}
 	}

--- a/VirtualDesktopServer2022.cs
+++ b/VirtualDesktopServer2022.cs
@@ -710,6 +710,8 @@ Console.WriteLine("Name of desktop: " + desktopName);
 			WindowInformation result = null;
 			EnumWindows((hWnd, lParam) => 
 			{
+				int length = GetWindowTextLength((IntPtr)hWnd);
+				sb.EnsureCapacity(length);
 				if (GetWindowText((IntPtr)hWnd, sb, sb.Capacity) > 0)
 				{
 					if (sb.ToString() == WindowTitle)


### PR DESCRIPTION
hello, I've used some of your code to implement my own version of Virtual Desktop, but instead of a CLI tool I made it into an background executable instead -> [vdm](https://github.com/NoseferatuWKF/vdm)

and while I was at it, I found that the FindWindow() method was taking some time to execute considering my workflow, so I tweaked it a bit, and wanted to contribute back to your repo. There is a caveat that `sb.ToString() == WindowTitle` keeps allocating memory, but I could not make it work using `sb.Equals()` for .NET framework 4.0

Good news is that it works on Windows 11, and bad news is that I could not test for others, so there's that. Anyways, please take a look at this PR cheers!
![Screenshot 2024-08-20 214118](https://github.com/user-attachments/assets/3375dc2e-d831-4c1e-afa8-50e879562a40)
